### PR TITLE
Potential fix for code scanning alert no. 36: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [main]
 
+permissions:
+  contents: read
+
 jobs:
   run-build:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/jbouder/acolyte/security/code-scanning/36](https://github.com/jbouder/acolyte/security/code-scanning/36)

Add a workflow-level `permissions` block to explicitly scope `GITHUB_TOKEN` to read-only access needed by checkout/build/test jobs.

Best fix here (without changing functionality): in `.github/workflows/code-quality.yml`, insert:

- `permissions:`
- `  contents: read`

right after the `on:` trigger section (before `jobs:`). This applies to all jobs (`run-build`, `run-check`, `run-test-checks`) and is sufficient for current steps. No imports, methods, or additional definitions are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
