### PR TITLE
Harden assistant reply parsing and enlarge launcher icon

### DIFF
--- a/__tests__/floating-assistant.test.tsx
+++ b/__tests__/floating-assistant.test.tsx
@@ -51,4 +51,59 @@ describe('FloatingAssistant', () => {
       'Unable to start the local assistant: Model unavailable',
     );
   });
+
+  async function sendPrompt(content: string) {
+    mockCreateMLCEngine.mockResolvedValueOnce({
+      chat: {
+        completions: {
+          create: jest.fn().mockResolvedValue({
+            choices: [{ message: { content } }],
+          }),
+        },
+      },
+    });
+
+    render(<FloatingAssistant />);
+    fireEvent.click(
+      screen.getByRole('button', { name: 'Open Acolyte assistant' }),
+    );
+
+    // Wait for the initial engine load to settle so the send handler is not
+    // short-circuited by the loading guard.
+    await waitFor(() => {
+      expect(
+        screen.getByRole('button', { name: 'Send message' }),
+      ).not.toBeDisabled();
+    });
+
+    fireEvent.change(
+      screen.getByRole('textbox', { name: 'Ask the assistant' }),
+      {
+        target: { value: 'hello' },
+      },
+    );
+    fireEvent.submit(
+      screen.getByRole('textbox', { name: 'Ask the assistant' }),
+    );
+  }
+
+  it('parses JSON wrapped in think tags and code fences', async () => {
+    await sendPrompt(
+      '<think>deciding</think>```json\n{"reply":"Hi there"}\n```',
+    );
+
+    expect(await screen.findByText('Hi there')).toBeInTheDocument();
+    expect(
+      screen.queryByText(/Unable to start the local assistant/),
+    ).not.toBeInTheDocument();
+  });
+
+  it('falls back to plain prose when the model does not return JSON', async () => {
+    await sendPrompt('Acolyte has several tools you can use.');
+
+    expect(
+      await screen.findByText('Acolyte has several tools you can use.'),
+    ).toBeInTheDocument();
+    expect(screen.queryByText(/is not valid JSON/)).not.toBeInTheDocument();
+  });
 });

--- a/components/floating-assistant.tsx
+++ b/components/floating-assistant.tsx
@@ -43,12 +43,69 @@ interface ModelReply {
   action?: AssistantAction;
 }
 
+function extractJsonObject(content: string): string | undefined {
+  // Small models often wrap their output in <think> blocks or markdown code
+  // fences, and sometimes add prose around the JSON. Strip the noise and pull
+  // out the first balanced { ... } object before parsing.
+  const withoutThinking = content.replace(/<think>[\s\S]*?<\/think>/gi, '');
+  const withoutFences = withoutThinking.replace(/```(?:json)?/gi, '');
+
+  const start = withoutFences.indexOf('{');
+  if (start === -1) return undefined;
+
+  let depth = 0;
+  let inString = false;
+  let escaped = false;
+  for (let i = start; i < withoutFences.length; i++) {
+    const char = withoutFences[i];
+    if (escaped) {
+      escaped = false;
+      continue;
+    }
+    if (char === '\\') {
+      escaped = true;
+      continue;
+    }
+    if (char === '"') {
+      inString = !inString;
+      continue;
+    }
+    if (inString) continue;
+    if (char === '{') depth++;
+    else if (char === '}') {
+      depth--;
+      if (depth === 0) return withoutFences.slice(start, i + 1);
+    }
+  }
+  return undefined;
+}
+
 function parseModelReply(content: string): ModelReply {
-  const parsed = JSON.parse(content) as ModelReply;
-  return {
-    reply: parsed.reply,
-    ...(isAssistantAction(parsed.action) ? { action: parsed.action } : {}),
-  };
+  const json = extractJsonObject(content);
+  if (json) {
+    try {
+      const parsed = JSON.parse(json) as ModelReply;
+      if (typeof parsed.reply === 'string') {
+        return {
+          reply: parsed.reply,
+          ...(isAssistantAction(parsed.action)
+            ? { action: parsed.action }
+            : {}),
+        };
+      }
+    } catch {
+      // Fall through to the plain-text fallback below.
+    }
+  }
+
+  // The model returned prose instead of JSON; surface it as the reply rather
+  // than failing the whole exchange.
+  const fallback = content
+    .replace(/<think>[\s\S]*?<\/think>/gi, '')
+    .replace(/```(?:json)?/gi, '')
+    .trim();
+  if (!fallback) throw new Error('The local model returned no response.');
+  return { reply: fallback };
 }
 
 const systemPrompt = `You are Acolyte's local assistant. Answer concise questions about the app using this catalog:
@@ -270,7 +327,7 @@ export function FloatingAssistant() {
       <Button
         aria-expanded={isOpen}
         aria-label="Open Acolyte assistant"
-        className="rounded-full shadow-lg"
+        className="size-14 rounded-full shadow-lg [&_svg:not([class*='size-'])]:size-6"
         onClick={() => setIsOpen((open) => !open)}
         size="icon"
       >


### PR DESCRIPTION
## Summary
- Fixes the floating assistant crashing with **\"Unable to start the local assistant: …is not valid JSON\"** — the tiny local Qwen3-0.6B model sometimes returns output that isn't strict JSON (leftover `<think>` tokens, markdown code fences, or plain prose), and `JSON.parse` threw, surfacing as a misleading *startup* failure.
- `parseModelReply` now strips think blocks and code fences, extracts the first balanced `{…}` object, and **falls back to showing the cleaned text as the reply** instead of throwing.
- Enlarges the launcher button to a 56px FAB with a proportional 24px icon.

## Testing
- Added unit tests for the think-tag/fence and plain-prose fallback paths.
- Full suite: **188 passed / 22 suites**; Biome clean.
- Verified end-to-end in real Chrome (WebGPU): model loads, prompts render with no crash.

🤖 Generated with [Claude Code](https://claude.com/claude-code)